### PR TITLE
Include some model's methods, added integer shortcut and other things

### DIFF
--- a/api/field-descriptors.md
+++ b/api/field-descriptors.md
@@ -58,6 +58,16 @@ static fields = {
 };
 ```
 
+### Integer
+
+Set a maximum number of digits for this field.
+
+```javascript
+static fields = {
+	quantity: DataTypes.integer(2)
+}
+```
+
 ## Descriptors
 
 Here is a list of all the field descriptors available:

--- a/api/field-descriptors.md
+++ b/api/field-descriptors.md
@@ -64,7 +64,7 @@ Set a maximum number of digits for this field.
 
 ```javascript
 static fields = {
-	quantity: DataTypes.integer(2)
+  quantity: DataTypes.integer(2)
 }
 ```
 

--- a/api/model-methods.md
+++ b/api/model-methods.md
@@ -109,7 +109,7 @@ await Flight.where(Flight.field('departure'), 'Paris')
   .get();
 ```
 
-### leftJoin
+## leftJoin
 
 Join a table with left statement to the current query. You might need to use `field` in case field names are overlapping (which might happen with `id`s).
 
@@ -119,14 +119,14 @@ await Flight.where(Flight.field('departure'), 'Paris')
 	.get();
 ```
 
-### leftOuterJoin
+## leftOuterJoin
 
 Join a table with left outer statement to the current query. You might need to use `field` in case field names are overlapping (which might happen with `id`s).
 
 ```typescript
 await Flight.where(Flight.field('departure'), 'Paris')
-	.leftOuterJoin(Airport, Airport.field('id'), Flight.field('airportId'))
-	.get();
+  .leftOuterJoin(Airport, Airport.field('id'), Flight.field('airportId'))
+  .get();
 ```
 
 ## limit

--- a/api/model-methods.md
+++ b/api/model-methods.md
@@ -109,6 +109,26 @@ await Flight.where(Flight.field('departure'), 'Paris')
   .get();
 ```
 
+### leftJoin
+
+Join a table with left statement to the current query. You might need to use `field` in case field names are overlapping (which might happen with `id`s).
+
+```typescript
+await Flight.where(Flight.field('departure'), 'Paris')
+	.leftJoin(Airport, Airport.field('id'), Flight.field('airportId'))
+	.get();
+```
+
+### leftOuterJoin
+
+Join a table with left outer statement to the current query. You might need to use `field` in case field names are overlapping (which might happen with `id`s).
+
+```typescript
+await Flight.where(Flight.field('departure'), 'Paris')
+	.leftOuterJoin(Airport, Airport.field('id'), Flight.field('airportId'))
+	.get();
+```
+
 ## limit
 
 Limit the number of results returned from the query.

--- a/api/model-methods.md
+++ b/api/model-methods.md
@@ -115,8 +115,8 @@ Join a table with left statement to the current query. You might need to use `fi
 
 ```typescript
 await Flight.where(Flight.field('departure'), 'Paris')
-	.leftJoin(Airport, Airport.field('id'), Flight.field('airportId'))
-	.get();
+  .leftJoin(Airport, Airport.field('id'), Flight.field('airportId'))
+  .get();
 ```
 
 ## leftOuterJoin

--- a/guides/connect-database.md
+++ b/guides/connect-database.md
@@ -24,5 +24,5 @@ Depending on the dialect, you might need different options:
 
 - [Using SQLite](guides/using-sqlite.md)
 - [Using PostegreSQL](guides/using-postgresql.md)
-- [Using MySQL](guides/using-mysql.md)
+- [Using MySQL (MariaDB)](guides/using-mysql.md)
 - [Using MongoDB](guides/using-mongodb.md)

--- a/guides/connect-database.md
+++ b/guides/connect-database.md
@@ -24,5 +24,5 @@ Depending on the dialect, you might need different options:
 
 - [Using SQLite](guides/using-sqlite.md)
 - [Using PostegreSQL](guides/using-postgresql.md)
-- [Using MySQL (MariaDB)](guides/using-mysql.md)
+- [Using MySQL](guides/using-mysql.md)
 - [Using MongoDB](guides/using-mongodb.md)

--- a/guides/foreign-key.md
+++ b/guides/foreign-key.md
@@ -155,7 +155,7 @@ class Business extends Model {
   }
 }
 
-db.link([Business, Owner]);
+db.link([Owner, Business]);
 
 await db.sync({ drop: true });
 


### PR DESCRIPTION
Hi, @eveningkid.  I wrote some things:

- leftJoin and leftOuterJoin
- Specification about MariaDB (https://github.com/eveningkid/denodb/issues/221)
- Integer shortcut
- Foreign key error on example (https://github.com/eveningkid/denodb/issues/207)

I code using vim on the WLS so I had some problems with the spaces and the tabs at method's example (that the reason of those 3 commits). :)